### PR TITLE
fix reference to documentation

### DIFF
--- a/pylonshq/templates/nav.mako
+++ b/pylonshq/templates/nav.mako
@@ -10,7 +10,7 @@
 	<div class="header-nav">
 		<ul>
 			<li><a href="${request.application_url}"${active_nav.get('home', '') | n}>Home</a></li>
-			<li><a href="https://docs.pylonsproject.org/">Documentation</a></li>
+			<li><a href="http://docs.pylonsproject.org/">Documentation</a></li>
 			<li>
 				<a href="${request.application_url}/about"${active_nav.get('about', '') | n}>About</a>
 				<div class="header-nav-submenu">


### PR DESCRIPTION
http://www.pylonsproject.org/

Currently the documentation isn't accessible via HTTPS, i.e.

https://docs.pylonsproject.org/ - This webpage is not available
but http://docs.pylonsproject.org/ works!

So, someone need to fix reference or to setup https for docs, JFYI :)

Thanks!
